### PR TITLE
Add an AppTab enum and rename ConfigTOML to ConfigToml

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -18,6 +18,24 @@ pub enum InputMode {
     Controls,
 }
 
+/// Represents the active tab state.
+#[derive(Debug, Clone, Copy)]
+pub enum AppTab {
+    Music = 0,
+    Controls,
+}
+
+impl AppTab {
+    /// Get the next tab in the list.
+    pub fn next(&self) -> Self {
+        match self {
+            Self::Music => Self::Controls,
+            // Wrap around to the first tab.
+            Self::Controls => Self::Music,
+        }
+    }
+}
+
 pub struct App<'a> {
     pub browser_items: StatefulList<String>,
     pub queue_items: Queue,
@@ -25,7 +43,7 @@ pub struct App<'a> {
     pub music_handle: MusicHandle,
     input_mode: InputMode,
     pub titles: Vec<&'a str>,
-    pub index: usize,
+    pub active_tab: AppTab,
 }
 
 impl<'a> App<'a> {
@@ -37,12 +55,12 @@ impl<'a> App<'a> {
             music_handle: MusicHandle::new(),
             input_mode: InputMode::Browser,
             titles: vec!["Music", "Controls"],
-            index: 0,
+            active_tab: AppTab::Music,
         }
     }
 
     pub fn next(&mut self) {
-        self.index = (self.index + 1) % self.titles.len();
+        self.active_tab = self.active_tab.next();
     }
 
     pub fn get_input_mode(&self) -> InputMode {

--- a/src/app.rs
+++ b/src/app.rs
@@ -63,7 +63,7 @@ impl<'a> App<'a> {
         self.active_tab = self.active_tab.next();
     }
 
-    pub fn get_input_mode(&self) -> InputMode {
+    pub fn input_mode(&self) -> InputMode {
         self.input_mode
     }
 
@@ -71,11 +71,11 @@ impl<'a> App<'a> {
         self.input_mode = in_mode
     }
 
-    pub fn get_current_song(&self) -> String {
+    pub fn current_song(&self) -> String {
         if self.music_handle.sink_empty() && self.queue_items.is_empty() {
             "CURRENT SONG".to_string()
         } else {
-            self.music_handle.get_currently_playing()
+            self.music_handle.currently_playing()
         }
     }
 
@@ -112,7 +112,7 @@ impl<'a> App<'a> {
     pub fn song_progress(&mut self) -> u16 {
         let progress = || {
             let percentage =
-                (self.music_handle.get_time_played() * 100) / self.music_handle.get_song_length();
+                (self.music_handle.time_played() * 100) / self.music_handle.song_length();
             if percentage >= 100 {
                 100
             } else {
@@ -140,7 +140,7 @@ impl<'a> App<'a> {
         if self.browser_items.empty() {
             Path::new(&current_dir).into()
         } else {
-            let join = Path::join(&current_dir, Path::new(&self.browser_items.get_item()));
+            let join = Path::join(&current_dir, Path::new(&self.browser_items.item()));
             join
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -131,40 +131,40 @@ impl Config {
         }
     }
 
-    // pub fn get_quit(&self) -> KeyCode {
+    // pub fn quit_key(&self) -> KeyCode {
 
     //     KeyCode::Char(self.quit)
     // }
 
-    // pub fn get_play_pause(&self) -> char {
+    // pub fn play_pause_key(&self) -> char {
     //     self.play_pause
     // }
 
-    // pub fn get_skip(&self) -> char {
+    // pub fn skip_key(&self) -> char {
     //     self.skip
     // }
 
-    // pub fn get_queue_add(&self) -> char {
+    // pub fn queue_add_key(&self) -> char {
     //     self.queue_add
     // }
 
-    // pub fn get_queue_remove(&self) -> char {
+    // pub fn queue_remove_key(&self) -> char {
     //     self.queue_remove
     // }
 
-    pub fn get_foreground(&self) -> Color {
+    pub fn foreground(&self) -> Color {
         self.foreground
     }
 
-    pub fn get_background(&self) -> Color {
+    pub fn background(&self) -> Color {
         self.background
     }
 
-    pub fn get_highlight_foreground(&self) -> Color {
+    pub fn highlight_foreground(&self) -> Color {
         self.highlight_foreground
     }
 
-    pub fn get_highlight_background(&self) -> Color {
+    pub fn highlight_background(&self) -> Color {
         self.highlight_background
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,7 @@ struct Theme {
 
 // for tables
 #[derive(Serialize, Deserialize, Debug)]
-struct ConfigTOML {
+struct ConfigToml {
     theme: Option<Theme>,
 }
 
@@ -54,10 +54,10 @@ impl Config {
         }
 
         // convert toml file to serialized data
-        let config_toml: ConfigTOML = toml::from_str(&content).unwrap_or_else(|_| {
+        let config_toml: ConfigToml = toml::from_str(&content).unwrap_or_else(|_| {
             // if config file not found, set defaults
             eprintln!("FAILED TO CREATE CONFIG OBJECT FROM FILE");
-            ConfigTOML { theme: None }
+            ConfigToml { theme: None }
         });
 
         // match theme

--- a/src/helpers/music_handler.rs
+++ b/src/helpers/music_handler.rs
@@ -37,15 +37,15 @@ impl MusicHandle {
         }
     }
 
-    pub fn get_currently_playing(&self) -> String {
+    pub fn currently_playing(&self) -> String {
         self.currently_playing.clone()
     }
 
-    pub fn get_song_length(&self) -> u16 {
+    pub fn song_length(&self) -> u16 {
         self.song_length
     }
 
-    pub fn get_time_played(&self) -> u16 {
+    pub fn time_played(&self) -> u16 {
         *self.time_played.lock().unwrap()
     }
 
@@ -76,7 +76,7 @@ impl MusicHandle {
             .unwrap()
             .to_string();
         self.set_currently_playing(&path);
-        self.song_length(&path);
+        self.update_song_length(&path);
 
         // reinitialize due to rodio crate
         self.sink = Arc::new(Sink::try_new(&self.music_output.1).unwrap());
@@ -124,7 +124,8 @@ impl MusicHandle {
         self.sink.stop();
     }
 
-    pub fn song_length(&mut self, path: &PathBuf) {
+    /// Update `self.song_length` with the provided file.
+    pub fn update_song_length(&mut self, path: &PathBuf) {
         let path = Path::new(&path);
         let tagged_file = Probe::open(path)
             .expect("ERROR: Bad path provided!")

--- a/src/helpers/queue.rs
+++ b/src/helpers/queue.rs
@@ -27,20 +27,20 @@ impl Queue {
     }
 
     // return item at index
-    pub fn get_item(&self) -> &PathBuf {
+    pub fn item(&self) -> &PathBuf {
         &self.items[self.curr]
     }
 
     // return all items contained in vector
-    pub fn get_items(&self) -> &VecDeque<PathBuf> {
+    pub fn items(&self) -> &VecDeque<PathBuf> {
         &self.items
     }
 
-    pub fn get_length(&self) -> usize {
+    pub fn length(&self) -> usize {
         self.items.len()
     }
 
-    pub fn get_total_time(&self) -> String {
+    pub fn total_time(&self) -> String {
         // days
         if self.total_time / SECONDS_PER_DAY >= 1 {
             let days = self.total_time / SECONDS_PER_DAY;
@@ -95,7 +95,7 @@ impl Queue {
         self.items.pop_front().unwrap()
     }
 
-    pub fn get_state(&self) -> ListState {
+    pub fn state(&self) -> ListState {
         self.state.clone()
     }
 

--- a/src/helpers/queue.rs
+++ b/src/helpers/queue.rs
@@ -179,9 +179,8 @@ impl Queue {
 
     // remove item from items vector
     pub fn remove(&mut self) {
-        if self.items.len() == 0{
-            return
-        // top of queue
+        if self.items.is_empty() {
+            // top of queue
         } else if self.items.len() == 1 {
             self.decrement_total_time();
             self.items.remove(self.curr);

--- a/src/helpers/stateful_list.rs
+++ b/src/helpers/stateful_list.rs
@@ -17,16 +17,16 @@ impl<T> StatefulList<T> {
     }
 
     // return all items contained in vector
-    pub fn get_items(&self) -> &Vec<T> {
+    pub fn items(&self) -> &Vec<T> {
         &self.items
     }
 
     // return item at index
-    pub fn get_item(&self) -> &T {
+    pub fn item(&self) -> &T {
         &self.items[self.curr]
     }
 
-    pub fn get_state(&self) -> ListState {
+    pub fn state(&self) -> ListState {
         self.state.clone()
     }
 

--- a/src/helpers/stateful_table.rs
+++ b/src/helpers/stateful_table.rs
@@ -33,11 +33,11 @@ impl<'a> StatefulTable<'a> {
         }
     }
 
-    // pub fn get_header(&self) -> Vec<&'a str> {
+    // pub fn header(&self) -> Vec<&'a str> {
     //     self.header
     // }
 
-    // pub fn get_items(&self) -> Vec<Vec<&'a str>> {
+    // pub fn items(&self) -> Vec<Vec<&'a str>> {
     //     self.items
     // }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use tui::{
     Frame, Terminal,
 };
 
-use app::{App, InputMode};
+use app::{App, AppTab, InputMode};
 use config::Config;
 use kronos::gen_funcs;
 
@@ -173,7 +173,7 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &mut App, cfg: &Config) {
     // Box Around Tab Items
     let tabs = Tabs::new(titles)
         .block(Block::default().borders(Borders::ALL).title("Tabs"))
-        .select(app.index)
+        .select(app.active_tab as usize)
         .style(Style::default().fg(cfg.get_foreground()))
         .highlight_style(
             Style::default()
@@ -182,10 +182,9 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &mut App, cfg: &Config) {
         );
     f.render_widget(tabs, chunks[0]);
 
-    match app.index {
-        0 => music_tab(f, app, chunks[1], cfg),
-        1 => instructions_tab(f, app, chunks[1], cfg),
-        _ => unreachable!(),
+    match app.active_tab {
+        AppTab::Music => music_tab(f, app, chunks[1], cfg),
+        AppTab::Controls => instructions_tab(f, app, chunks[1], cfg),
     };
 }
 


### PR DESCRIPTION
# Purpose

This PR adds further readability and maintainability improvements.

# Summary

* Add an `AppTab` enum to track the active tab.
* Rename `ConfigTOML` to `ConfigToml` to conform to [Rust RFC 430](https://rust-lang.github.io/api-guidelines/naming.html#casing-conforms-to-rfc-430-c-case).
    > In `UpperCamelCase`, acronyms and contractions of compound words count as one word: use `Uuid` rather than `UUID`, `Usize` rather than `USize` or `Stdin` rather than `StdIn`. In `snake_case`, acronyms and contractions are lower-cased: `is_xid_start`.
* Getters have been renamed to not use the `get_` prefix as recommended by the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter).
    > With a few exceptions, the `get_` prefix is not used for getters in Rust code.
    > [...]
    > The `get` naming is used only when there is a single and obvious thing that could reasonably be gotten by a getter. For example [`Cell::get`](https://doc.rust-lang.org/std/cell/struct.Cell.html#method.get) accesses the content of a `Cell`.
* Clippy's suggestions for the `queue` module's `remove()` function have been applied.
    ```
    ❯ cargo clippy
    warning: unneeded `return` statement
       --> src/helpers/queue.rs:182:35
        |
    182 |           if self.items.len() == 0 {
        |  ___________________________________^
    183 | |             return;
        | |__________________^
        |
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#need
    less_return
        = note: `#[warn(clippy::needless_return)]` on by default
        = help: remove `return`
    
    warning: length comparison to zero
       --> src/helpers/queue.rs:182:12
        |
    182 |         if self.items.len() == 0 {
        |            ^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `self.items.
    is_empty()`
        |
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_
    zero
        = note: `#[warn(clippy::len_zero)]` on by default
    
    warning: `kronos` (lib) generated 2 warnings
        Finished dev [unoptimized + debuginfo] target(s) in 0.06s
    ```