### PR TITLE
Add Rustfmt and Clippy GitHub Actions Jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,3 +92,27 @@ jobs:
         with:
           command: fmt
           args: --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install latest stable
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: clippy
+
+      - name: Install developer package dependencies
+        run: sudo apt-get update && sudo apt-get install libasound2-dev
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,8 +73,22 @@ jobs:
         with:
           command: test
 
-      
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
 
-     
+      - name: Install latest stable
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt
 
-     
+      - name: Enforce formatting
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --check

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,14 +13,14 @@ struct Theme {
 
 #[derive(Serialize, Deserialize, Debug)]
 struct Layout {
-    progress_bar: Option<u16>
+    progress_bar: Option<u16>,
 }
 
 // for tables
 #[derive(Serialize, Deserialize, Debug)]
 struct ConfigToml {
     theme: Option<Theme>,
-    layout: Option<Layout>
+    layout: Option<Layout>,
 }
 
 // everything
@@ -30,7 +30,7 @@ pub struct Config {
     background: Color,
     highlight_foreground: Color,
     highlight_background: Color,
-    progress_bar: u16
+    progress_bar: u16,
 }
 
 impl Default for Config {
@@ -64,9 +64,9 @@ impl Config {
         let config_toml: ConfigToml = toml::from_str(&content).unwrap_or_else(|_| {
             // if config file not found, set defaults
             eprintln!("FAILED TO CREATE CONFIG OBJECT FROM FILE");
-            ConfigToml { 
+            ConfigToml {
                 theme: None,
-                layout: None 
+                layout: None,
             }
         });
 
@@ -129,9 +129,7 @@ impl Config {
         };
 
         let progress_bar = match config_toml.layout {
-            Some(i) => {
-               i.progress_bar.unwrap_or(35)
-            }, 
+            Some(i) => i.progress_bar.unwrap_or(35),
             None => 35,
         };
 

--- a/src/helpers/queue.rs
+++ b/src/helpers/queue.rs
@@ -26,10 +26,9 @@ impl Queue {
         }
     }
 
-     // return item at index
-     pub fn item(&self) -> Option<&PathBuf> {
-
-        if self.items.is_empty(){
+    // return item at index
+    pub fn item(&self) -> Option<&PathBuf> {
+        if self.items.is_empty() {
             None
         } else {
             Some(&self.items[self.curr])

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,11 +102,9 @@ fn run_app<B: Backend>(
                         KeyCode::Char('p') => app.music_handle.play_pause(),
                         KeyCode::Char('g') => app.music_handle.skip(),
                         KeyCode::Enter => {
-
-                            if let Some(i) = app.queue_items.item(){
+                            if let Some(i) = app.queue_items.item() {
                                 app.music_handle.play(i.clone());
                             };
-                            
                         }
                         KeyCode::Down | KeyCode::Char('j') => app.queue_items.next(),
                         KeyCode::Up | KeyCode::Char('k') => app.queue_items.previous(),
@@ -205,7 +203,13 @@ fn music_tab<B: Backend>(f: &mut Frame<B>, app: &mut App, chunks: Rect, cfg: &Co
     // queue and playing sections (sltdkh)
     let queue_playing = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Percentage(100 - cfg.progress_bar()), Constraint::Percentage(cfg.progress_bar())].as_ref())
+        .constraints(
+            [
+                Constraint::Percentage(100 - cfg.progress_bar()),
+                Constraint::Percentage(cfg.progress_bar()),
+            ]
+            .as_ref(),
+        )
         .split(browser_queue[1]);
 
     // convert app items to text


### PR DESCRIPTION
This adds jobs to run `cargo fmt` and `cargo clippy` to ensure new code is compliant with the built-in formatter and the Clippy linter. Running Clippy will help catch common Rust mistakes and non-idiomatic code.