### PR TITLE
feat: remember selected path

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -44,6 +44,7 @@ pub struct App<'a> {
     input_mode: InputMode,
     pub titles: Vec<&'a str>,
     pub active_tab: AppTab,
+    pub path_buf: PathBuf,
 }
 
 impl<'a> App<'a> {
@@ -56,6 +57,7 @@ impl<'a> App<'a> {
             input_mode: InputMode::Browser,
             titles: vec!["Music", "Controls"],
             active_tab: AppTab::Music,
+            path_buf: env::current_dir().unwrap(),
         }
     }
 
@@ -84,6 +86,7 @@ impl<'a> App<'a> {
         let join = self.selected_item();
         // if folder enter, else play song
         if join.is_dir() {
+            self.path_buf = join.clone();
             env::set_current_dir(join).unwrap();
             self.browser_items = StatefulList::with_items(gen_funcs::scan_and_filter_directory());
             self.browser_items.next();
@@ -96,7 +99,7 @@ impl<'a> App<'a> {
     pub fn backpedal(&mut self) {
         env::set_current_dir("../").unwrap();
         self.browser_items = StatefulList::with_items(gen_funcs::scan_and_filter_directory());
-        self.browser_items.next();
+        self.browser_items.select_by_path(&self.path_buf);
     }
 
     // if queue has items and nothing playing, auto play

--- a/src/app.rs
+++ b/src/app.rs
@@ -44,7 +44,7 @@ pub struct App<'a> {
     input_mode: InputMode,
     pub titles: Vec<&'a str>,
     pub active_tab: AppTab,
-    pub path_buf: PathBuf,
+    pub last_visited_path: PathBuf,
 }
 
 impl<'a> App<'a> {
@@ -57,7 +57,7 @@ impl<'a> App<'a> {
             input_mode: InputMode::Browser,
             titles: vec!["Music", "Controls"],
             active_tab: AppTab::Music,
-            path_buf: env::current_dir().unwrap(),
+            last_visited_path: env::current_dir().unwrap(),
         }
     }
 
@@ -86,7 +86,7 @@ impl<'a> App<'a> {
         let join = self.selected_item();
         // if folder enter, else play song
         if join.is_dir() {
-            self.path_buf = join.clone();
+            self.last_visited_path = join.clone();
             env::set_current_dir(join).unwrap();
             self.browser_items = StatefulList::with_items(gen_funcs::scan_and_filter_directory());
             self.browser_items.next();
@@ -99,7 +99,7 @@ impl<'a> App<'a> {
     pub fn backpedal(&mut self) {
         env::set_current_dir("../").unwrap();
         self.browser_items = StatefulList::with_items(gen_funcs::scan_and_filter_directory());
-        self.browser_items.select_by_path(&self.path_buf);
+        self.browser_items.select_by_path(&self.last_visited_path);
     }
 
     // if queue has items and nothing playing, auto play

--- a/src/helpers/stateful_list.rs
+++ b/src/helpers/stateful_list.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use tui::widgets::ListState;
 
 // TODO encapsulation
@@ -76,5 +77,25 @@ impl<T> StatefulList<T> {
 
     pub fn unselect(&mut self) {
         self.state.select(None);
+    }
+    pub fn select(&mut self, i: usize) {
+        self.curr = i;
+        self.state.select(Some(i));
+    }
+}
+
+impl<T: ToString> StatefulList<T> {
+    pub fn select_by_path(&mut self, s: &PathBuf) {
+        let items = self.items();
+        let mut i = 0;
+
+        for n in 0 .. items.len() {
+            if (s.ends_with(items[n].to_string())) {
+                i = n;
+                break;
+            }
+        }
+
+        self.select(i);
     }
 }

--- a/src/helpers/stateful_list.rs
+++ b/src/helpers/stateful_list.rs
@@ -89,7 +89,7 @@ impl<T: ToString> StatefulList<T> {
         let mut i = 0;
 
         for n in 0 .. self.items.len() {
-            if (s.ends_with(self.items[n].to_string())) {
+            if s.ends_with(self.items[n].to_string()) {
                 i = n;
                 break;
             }

--- a/src/helpers/stateful_list.rs
+++ b/src/helpers/stateful_list.rs
@@ -85,17 +85,19 @@ impl<T> StatefulList<T> {
 }
 
 impl<T: ToString> StatefulList<T> {
-    pub fn select_by_path(&mut self, s: &PathBuf) {
-        let items = self.items();
+    pub fn find_by_path(&self, s: &PathBuf) -> usize {
         let mut i = 0;
 
-        for n in 0 .. items.len() {
-            if (s.ends_with(items[n].to_string())) {
+        for n in 0 .. self.items.len() {
+            if (s.ends_with(self.items[n].to_string())) {
                 i = n;
                 break;
             }
         }
 
-        self.select(i);
+        i
+    }
+    pub fn select_by_path(&mut self, s: &PathBuf) {
+        self.select(self.find_by_path(s));
     }
 }


### PR DESCRIPTION
Hey @TrevorSatori! 

This PR adds a feature: remembering which path was selected when entering into a directory, and selecting it (rather than the first item of the directory list) when navigating upwards.

---

This is my first time writing Rust, so the code is probably pretty lousy. The `for n in 0` looks like it could be more succinct (I couldn't find a native `.findIndex` or equivalent) and I'm not sure I'm passing the variables with the least scope possible, everywhere (borrowing immutably everywhere it's possible, etc).

The commit messages I wrote aren't useful outside the context of this PR, so if you do accept it, I think using the `squash merge` option would be ideal.

All feedback will be much appreciated :pray: 