### PR TITLE
feat: persist last_visited_path

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -48,7 +48,14 @@ pub struct App<'a> {
 }
 
 impl<'a> App<'a> {
-    pub fn new() -> Self {
+    pub fn new(initial_directory: Option<String>) -> Self {
+        if let Some(path) = initial_directory {
+            env::set_current_dir(&path).unwrap_or_else(|err| {
+                eprintln!("Could not set_current_dir to last_visited_path\n\tPath: {}\n\tError: {:?}", path, err);
+                eprintln!("last_visited_path was: {:?}", &path);
+            });
+        }
+
         Self {
             browser_items: StatefulList::with_items(gen_funcs::scan_and_filter_directory()),
             queue_items: Queue::with_items(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -44,6 +44,7 @@ pub struct App<'a> {
     input_mode: InputMode,
     pub titles: Vec<&'a str>,
     pub active_tab: AppTab,
+    pub path_buf: PathBuf,
 }
 
 impl<'a> App<'a> {
@@ -56,6 +57,7 @@ impl<'a> App<'a> {
             input_mode: InputMode::Browser,
             titles: vec!["Music", "Controls"],
             active_tab: AppTab::Music,
+            path_buf: env::current_dir().unwrap(),
         }
     }
 
@@ -84,6 +86,7 @@ impl<'a> App<'a> {
         let join = self.selected_item();
         // if folder enter, else play song
         if join.is_dir() {
+            self.path_buf = join.clone();
             env::set_current_dir(join).unwrap();
             self.browser_items = StatefulList::with_items(gen_funcs::scan_and_filter_directory());
             self.browser_items.next();
@@ -96,7 +99,7 @@ impl<'a> App<'a> {
     pub fn backpedal(&mut self) {
         env::set_current_dir("../").unwrap();
         self.browser_items = StatefulList::with_items(gen_funcs::scan_and_filter_directory());
-        self.browser_items.next();
+        self.browser_items.select_by_path(&self.path_buf);
     }
 
     // if queue has items and nothing playing, auto play

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,6 +10,7 @@ use kronos::music_handler::MusicHandle;
 use kronos::queue::Queue;
 use kronos::stateful_list::StatefulList;
 use kronos::stateful_table::StatefulTable;
+use crate::state::{save_state, StateToml};
 
 #[derive(Clone, Copy)]
 pub enum InputMode {
@@ -66,6 +67,14 @@ impl<'a> App<'a> {
             active_tab: AppTab::Music,
             last_visited_path: env::current_dir().unwrap(),
         }
+    }
+
+    pub fn save_state(self) {
+        save_state(StateToml {
+            last_visited_path: self.last_visited_path.to_str().map(String::from),
+        }).unwrap_or_else(|error| {
+            eprintln!("Error in save_state {}", error);
+        });
     }
 
     pub fn next(&mut self) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -44,7 +44,7 @@ pub struct App<'a> {
     input_mode: InputMode,
     pub titles: Vec<&'a str>,
     pub active_tab: AppTab,
-    pub path_buf: PathBuf,
+    pub last_visited_path: PathBuf,
 }
 
 impl<'a> App<'a> {
@@ -57,7 +57,7 @@ impl<'a> App<'a> {
             input_mode: InputMode::Browser,
             titles: vec!["Music", "Controls"],
             active_tab: AppTab::Music,
-            path_buf: env::current_dir().unwrap(),
+            last_visited_path: env::current_dir().unwrap(),
         }
     }
 
@@ -86,7 +86,7 @@ impl<'a> App<'a> {
         let join = self.selected_item();
         // if folder enter, else play song
         if join.is_dir() {
-            self.path_buf = join.clone();
+            self.last_visited_path = join.clone();
             env::set_current_dir(join).unwrap();
             self.browser_items = StatefulList::with_items(gen_funcs::scan_and_filter_directory());
             self.browser_items.next();
@@ -99,7 +99,7 @@ impl<'a> App<'a> {
     pub fn backpedal(&mut self) {
         env::set_current_dir("../").unwrap();
         self.browser_items = StatefulList::with_items(gen_funcs::scan_and_filter_directory());
-        self.browser_items.select_by_path(&self.path_buf);
+        self.browser_items.select_by_path(&self.last_visited_path);
     }
 
     // if queue has items and nothing playing, auto play

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,7 +10,7 @@ use kronos::music_handler::MusicHandle;
 use kronos::queue::Queue;
 use kronos::stateful_list::StatefulList;
 use kronos::stateful_table::StatefulTable;
-use crate::state::{save_state, StateToml};
+use crate::state::{save_state, State};
 
 #[derive(Clone, Copy)]
 pub enum InputMode {
@@ -70,7 +70,7 @@ impl<'a> App<'a> {
     }
 
     pub fn save_state(self) {
-        save_state(StateToml {
+        save_state(State {
             last_visited_path: self.last_visited_path.to_str().map(String::from),
         }).unwrap_or_else(|error| {
             eprintln!("Error in save_state {}", error);

--- a/src/app.rs
+++ b/src/app.rs
@@ -128,28 +128,19 @@ impl<'a> App<'a> {
     }
 
     // if playing and
-    pub fn song_progress(&mut self) -> u16 {
-        let progress = || {
-            let percentage =
-                (self.music_handle.time_played() * 100) / self.music_handle.song_length();
-            if percentage >= 100 {
-                100
-            } else {
-                percentage
-            }
-        };
-
+    pub fn song_progress(&mut self) -> f64 {
         // edge case if nothing queued or playing
         if self.music_handle.sink_empty() && self.queue_items.is_empty() {
-            0
+            0.0
 
         // if something playing, calculate progress
         } else if !self.music_handle.sink_empty() {
-            progress()
+            // progress()
+            self.music_handle.time_played() as f64 / self.music_handle.song_length() as f64
         // if nothing playing keep rolling
         } else {
             self.auto_play();
-            0
+            0.0
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -53,7 +53,6 @@ impl<'a> App<'a> {
         if let Some(path) = initial_directory {
             env::set_current_dir(&path).unwrap_or_else(|err| {
                 eprintln!("Could not set_current_dir to last_visited_path\n\tPath: {}\n\tError: {:?}", path, err);
-                eprintln!("last_visited_path was: {:?}", &path);
             });
         }
 

--- a/src/helpers/music_handler.rs
+++ b/src/helpers/music_handler.rs
@@ -15,8 +15,8 @@ use super::gen_funcs;
 pub struct MusicHandle {
     music_output: Arc<(OutputStream, OutputStreamHandle)>,
     sink: Arc<Sink>,
-    song_length: u16,
-    time_played: Arc<Mutex<u16>>,
+    song_length: u32,
+    time_played: Arc<Mutex<u32>>,
     currently_playing: String,
     volume: f32,
 }
@@ -43,11 +43,11 @@ impl MusicHandle {
         self.currently_playing.clone()
     }
 
-    pub fn song_length(&self) -> u16 {
+    pub fn song_length(&self) -> u32 {
         self.song_length
     }
 
-    pub fn time_played(&self) -> u16 {
+    pub fn time_played(&self) -> u32 {
         *self.time_played.lock().unwrap()
     }
 
@@ -55,7 +55,7 @@ impl MusicHandle {
         self.sink.empty()
     }
 
-    pub fn set_time_played(&mut self, t: u16) {
+    pub fn set_time_played(&mut self, t: u32) {
         *self.time_played.lock().unwrap() = t;
     }
     // set currently playing song
@@ -138,7 +138,7 @@ impl MusicHandle {
         let duration = properties.duration();
 
         // update song length, currently playing
-        self.song_length = duration.as_secs() as u16;
+        self.song_length = duration.as_secs() as u32;
     }
 
     pub fn change_volume(&mut self, volume: f32) {

--- a/src/helpers/stateful_list.rs
+++ b/src/helpers/stateful_list.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use tui::widgets::ListState;
 
 // TODO encapsulation
@@ -76,5 +77,25 @@ impl<T> StatefulList<T> {
 
     pub fn unselect(&mut self) {
         self.state.select(None);
+    }
+    pub fn select(&mut self, i: usize) {
+        self.curr = i;
+        self.state.select(Some(i));
+    }
+}
+
+impl<T: ToString> StatefulList<T> {
+    pub fn select_by_path(&mut self, s: &PathBuf) {
+        let items = self.items();
+        let mut i = 0;
+
+        for n in 0 .. items.len() {
+            if (s.ends_with(items[n].to_string())) {
+                i = n;
+                break;
+            }
+        }
+
+        self.select(i);
     }
 }

--- a/src/helpers/stateful_list.rs
+++ b/src/helpers/stateful_list.rs
@@ -89,7 +89,7 @@ impl<T: ToString> StatefulList<T> {
         let mut i = 0;
 
         for n in 0 .. self.items.len() {
-            if (s.ends_with(self.items[n].to_string())) {
+            if s.ends_with(self.items[n].to_string()) {
                 i = n;
                 break;
             }

--- a/src/helpers/stateful_list.rs
+++ b/src/helpers/stateful_list.rs
@@ -85,17 +85,19 @@ impl<T> StatefulList<T> {
 }
 
 impl<T: ToString> StatefulList<T> {
-    pub fn select_by_path(&mut self, s: &PathBuf) {
-        let items = self.items();
+    pub fn find_by_path(&self, s: &PathBuf) -> usize {
         let mut i = 0;
 
-        for n in 0 .. items.len() {
-            if (s.ends_with(items[n].to_string())) {
+        for n in 0 .. self.items.len() {
+            if (s.ends_with(self.items[n].to_string())) {
                 i = n;
                 break;
             }
         }
 
-        self.select(i);
+        i
+    }
+    pub fn select_by_path(&mut self, s: &PathBuf) {
+        self.select(self.find_by_path(s));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,11 +22,12 @@ use app::{App, AppTab, InputMode};
 use config::Config;
 use kronos::gen_funcs;
 use state::load_state;
+use crate::state::save_state;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let state = load_state();
+    let mut state = load_state();
 
-    if let Some(path) = state.last_visited_path {
+    if let Some(path) = &state.last_visited_path {
         env::set_current_dir(&path).unwrap_or_else(|err| {
             eprintln!("last_visited_path error: {:?}", err);
             eprintln!("last_visited_path was: {:?}", &path);
@@ -56,6 +57,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         DisableMouseCapture
     )?;
     terminal.show_cursor()?;
+
+    if let Ok(currentPath) = env::current_dir() {
+        state.last_visited_path = currentPath.to_str().map(|s| s.to_string());
+        save_state(&state);
+    }
 
     if let Err(err) = res {
         eprintln!("{:?}", err)

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     if let Ok(current_path) = env::current_dir() {
         save_state(StateToml {
             last_visited_path: current_path.to_str().map(|s| s.to_string()),
+        }).unwrap_or_else(|error| {
+            eprintln!("Error in save_state {}", error);
         });
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ mod app;
 mod config;
 mod state;
 
-use std::{env, error::Error, io, time::{Duration, Instant}};
+use std::{error::Error, io, time::{Duration, Instant}};
 
 use crossterm::{
     event::{self, DisableMouseCapture, Event, KeyCode},
@@ -22,7 +22,6 @@ use app::{App, AppTab, InputMode};
 use config::Config;
 use kronos::gen_funcs;
 use state::load_state;
-use crate::state::{save_state, State};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let state = load_state();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,8 @@
 mod app;
 mod config;
+mod state;
 
-use std::{
-    error::Error,
-    io,
-    time::{Duration, Instant},
-};
+use std::{env, error::Error, io, time::{Duration, Instant}};
 
 use crossterm::{
     event::{self, DisableMouseCapture, Event, KeyCode},
@@ -24,8 +21,18 @@ use tui::{
 use app::{App, AppTab, InputMode};
 use config::Config;
 use kronos::gen_funcs;
+use state::load_state;
 
 fn main() -> Result<(), Box<dyn Error>> {
+    let state = load_state();
+
+    if let Some(path) = state.last_visited_path {
+        env::set_current_dir(&path).unwrap_or_else(|err| {
+            eprintln!("last_visited_path error: {:?}", err);
+            eprintln!("last_visited_path was: {:?}", &path);
+        });
+    }
+
     // setup terminal
     enable_raw_mode()?;
     let mut stdout = io::stdout();

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,7 @@ fn run_app<B: Backend>(
             if let Event::Key(key) = event::read()? {
                 match app.input_mode() {
                     InputMode::Browser => match key.code {
-                        KeyCode::Char('q') => return Ok(()),
+                        KeyCode::Char('q') => break,
                         KeyCode::Char('p') | KeyCode::Char(' ') => app.music_handle.play_pause(),
                         KeyCode::Char('g') => app.music_handle.skip(),
                         KeyCode::Char('a') => app.queue_items.add(app.selected_item()),
@@ -109,7 +109,7 @@ fn run_app<B: Backend>(
                         _ => {}
                     },
                     InputMode::Queue => match key.code {
-                        KeyCode::Char('q') => return Ok(()),
+                        KeyCode::Char('q') => break,
                         KeyCode::Char('p') => app.music_handle.play_pause(),
                         KeyCode::Char('g') => app.music_handle.skip(),
                         KeyCode::Enter => {
@@ -135,7 +135,7 @@ fn run_app<B: Backend>(
                         _ => {}
                     },
                     InputMode::Controls => match key.code {
-                        KeyCode::Char('q') => return Ok(()),
+                        KeyCode::Char('q') => break,
                         KeyCode::Char('p') => app.music_handle.play_pause(),
                         KeyCode::Char('g') => app.music_handle.skip(),
                         KeyCode::Down | KeyCode::Char('j') => app.control_table.next(),
@@ -156,6 +156,10 @@ fn run_app<B: Backend>(
             last_tick = Instant::now();
         }
     }
+
+    app.save_state();
+
+    Ok(())
 }
 
 fn ui<B: Backend>(f: &mut Frame<B>, app: &mut App, cfg: &Config) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use app::{App, AppTab, InputMode};
 use config::Config;
 use kronos::gen_funcs;
 use state::load_state;
-use crate::state::{save_state, StateToml};
+use crate::state::{save_state, State};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let state = load_state();
@@ -50,14 +50,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         DisableMouseCapture
     )?;
     terminal.show_cursor()?;
-
-    if let Ok(current_path) = env::current_dir() {
-        save_state(StateToml {
-            last_visited_path: current_path.to_str().map(|s| s.to_string()),
-        }).unwrap_or_else(|error| {
-            eprintln!("Error in save_state {}", error);
-        });
-    }
 
     if let Err(err) = res {
         eprintln!("{:?}", err)

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,7 +289,7 @@ fn music_tab<B: Backend>(f: &mut Frame<B>, app: &mut App, chunks: Rect, cfg: &Co
         )
         .style(Style::default().fg(cfg.foreground()))
         .gauge_style(Style::default().fg(cfg.highlight_background()))
-        .percent(app.song_progress());
+        .ratio(app.song_progress());
     f.render_widget(playing, queue_playing[1]);
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -33,3 +33,14 @@ pub fn load_state() -> StateToml {
 
     state_toml
 }
+pub fn save_state(state: &StateToml) {
+    let state_file_path = home::home_dir()
+        .unwrap()
+        .as_path()
+        .join(".config/kronos/state.toml");
+
+    if let Ok(serialized) = toml::to_string(state) {
+        fs::write(state_file_path, serialized);
+        // TODO: not ignore IO result
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,35 @@
+use std::fs;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct StateToml {
+    pub last_visited_path: Option<String>,
+}
+
+pub fn load_state() -> StateToml {
+    let state_file_paths = [home::home_dir()
+        .unwrap()
+        .as_path()
+        .join(".config/kronos/state.toml")];
+
+    let mut content: String = "".to_owned();
+
+    for state_file_path in state_file_paths {
+        let result: Result<String, std::io::Error> = fs::read_to_string(state_file_path);
+
+        if let Ok(file_content) = result {
+            content = file_content;
+            break;
+        }
+    }
+
+    let state_toml: StateToml = toml::from_str(&content).unwrap_or_else(|_| {
+        eprintln!("FAILED TO CREATE STATE OBJECT FROM FILE");
+        StateToml {
+            last_visited_path: None,
+        }
+    });
+
+    state_toml
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -33,14 +33,15 @@ pub fn load_state() -> StateToml {
 
     state_toml
 }
-pub fn save_state(state: &StateToml) {
+pub fn save_state(state: StateToml) {
     let state_file_path = home::home_dir()
         .unwrap()
         .as_path()
         .join(".config/kronos/state.toml");
 
-    if let Ok(serialized) = toml::to_string(state) {
-        fs::write(state_file_path, serialized);
-        // TODO: not ignore IO result
+    if let Ok(serialized) = toml::to_string(&state) {
+        if let Err(error) = fs::write(state_file_path, serialized) {
+            eprintln!("Error {}", error);
+        };
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,11 +3,11 @@ use std::fs;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct StateToml {
+pub struct State {
     pub last_visited_path: Option<String>,
 }
 
-pub fn load_state() -> StateToml {
+pub fn load_state() -> State {
     let state_file_paths = [home::home_dir()
         .unwrap()
         .as_path()
@@ -24,16 +24,16 @@ pub fn load_state() -> StateToml {
         }
     }
 
-    let state_toml: StateToml = toml::from_str(&content).unwrap_or_else(|_| {
+    let state_toml: State = toml::from_str(&content).unwrap_or_else(|_| {
         eprintln!("FAILED TO CREATE STATE OBJECT FROM FILE");
-        StateToml {
+        State {
             last_visited_path: None,
         }
     });
 
     state_toml
 }
-pub fn save_state(state: StateToml) -> Result<(), String> {
+pub fn save_state(state: State) -> Result<(), String> {
     let state_file_path = home::home_dir()
         .unwrap()
         .as_path()

--- a/src/state.rs
+++ b/src/state.rs
@@ -33,15 +33,12 @@ pub fn load_state() -> StateToml {
 
     state_toml
 }
-pub fn save_state(state: StateToml) {
+pub fn save_state(state: StateToml) -> Result<(), String> {
     let state_file_path = home::home_dir()
         .unwrap()
         .as_path()
         .join(".config/kronos/state.toml");
 
-    if let Ok(serialized) = toml::to_string(&state) {
-        if let Err(error) = fs::write(state_file_path, serialized) {
-            eprintln!("Error {}", error);
-        };
-    }
+    toml::to_string(&state).map_err(|e| e.to_string())
+        .and_then(|serialized| fs::write(state_file_path, serialized).map_err(|e| e.to_string()))
 }


### PR DESCRIPTION
This PR adds a new feature: persisting the `last_visited_path` in a file, `.config/kronos/state.toml`.

This is saved when closing the program, and loaded when opening it, so the selected path stays the same between sessions of the application rather than resetting to what the current working directory is when the program is started.

---

Note: this branch includes the changes from https://github.com/TrevorSatori/kronos/pull/29, so the diff is a bit messy.

I'm creating this one as a _draft pull request_ for this reason: we should avoid merging it before https://github.com/TrevorSatori/kronos/pull/29, and I'll need to update this PR/branch after/if PR29 is merged.

