### PR TITLE
fix: overflow in percentage calculation 

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -116,7 +116,7 @@ impl<'a> App<'a> {
             if percentage >= 100 {
                 100
             } else {
-                percentage
+                u16::try_from(percentage).unwrap_or(100)
             }
         };
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use std::{
     thread,
     time::Duration,
 };
-
+use std::cmp::min;
 use kronos::gen_funcs;
 use kronos::music_handler::MusicHandle;
 use kronos::queue::Queue;
@@ -111,13 +111,8 @@ impl<'a> App<'a> {
     // if playing and
     pub fn song_progress(&mut self) -> u16 {
         let progress = || {
-            let percentage =
-                (self.music_handle.time_played() * 100) / self.music_handle.song_length();
-            if percentage >= 100 {
-                100
-            } else {
-                u16::try_from(percentage).unwrap_or(100)
-            }
+            let percentage: f32 = (self.music_handle.time_played() as f32 / self.music_handle.song_length() as f32) * 100.0;
+            min(percentage.round() as u16, 100)
         };
 
         // edge case if nothing queued or playing

--- a/src/helpers/music_handler.rs
+++ b/src/helpers/music_handler.rs
@@ -15,8 +15,8 @@ use super::gen_funcs;
 pub struct MusicHandle {
     music_output: Arc<(OutputStream, OutputStreamHandle)>,
     sink: Arc<Sink>,
-    song_length: u32,
-    time_played: Arc<Mutex<u32>>,
+    song_length: u16,
+    time_played: Arc<Mutex<u16>>,
     currently_playing: String,
     volume: f32,
 }
@@ -43,11 +43,11 @@ impl MusicHandle {
         self.currently_playing.clone()
     }
 
-    pub fn song_length(&self) -> u32 {
+    pub fn song_length(&self) -> u16 {
         self.song_length
     }
 
-    pub fn time_played(&self) -> u32 {
+    pub fn time_played(&self) -> u16 {
         *self.time_played.lock().unwrap()
     }
 
@@ -55,7 +55,7 @@ impl MusicHandle {
         self.sink.empty()
     }
 
-    pub fn set_time_played(&mut self, t: u32) {
+    pub fn set_time_played(&mut self, t: u16) {
         *self.time_played.lock().unwrap() = t;
     }
     // set currently playing song
@@ -138,7 +138,7 @@ impl MusicHandle {
         let duration = properties.duration();
 
         // update song length, currently playing
-        self.song_length = duration.as_secs() as u32;
+        self.song_length = duration.as_secs() as u16;
     }
 
     pub fn change_volume(&mut self, volume: f32) {

--- a/src/helpers/music_handler.rs
+++ b/src/helpers/music_handler.rs
@@ -15,8 +15,8 @@ use super::gen_funcs;
 pub struct MusicHandle {
     music_output: Arc<(OutputStream, OutputStreamHandle)>,
     sink: Arc<Sink>,
-    song_length: u16,
-    time_played: Arc<Mutex<u16>>,
+    song_length: u32,
+    time_played: Arc<Mutex<u32>>,
     currently_playing: String,
     volume: f32,
 }
@@ -43,11 +43,11 @@ impl MusicHandle {
         self.currently_playing.clone()
     }
 
-    pub fn song_length(&self) -> u16 {
+    pub fn song_length(&self) -> u32 {
         self.song_length
     }
 
-    pub fn time_played(&self) -> u16 {
+    pub fn time_played(&self) -> u32 {
         *self.time_played.lock().unwrap()
     }
 
@@ -55,7 +55,7 @@ impl MusicHandle {
         self.sink.empty()
     }
 
-    pub fn set_time_played(&mut self, t: u16) {
+    pub fn set_time_played(&mut self, t: u32) {
         *self.time_played.lock().unwrap() = t;
     }
     // set currently playing song
@@ -138,7 +138,7 @@ impl MusicHandle {
         let duration = properties.duration();
 
         // update song length, currently playing
-        self.song_length = duration.as_secs() as u16;
+        self.song_length = duration.as_secs() as u32;
     }
 
     pub fn change_volume(&mut self, volume: f32) {


### PR DESCRIPTION
Happens when the playing progress reaches ~7 minutes.

---

Update: I realized this can be even simpler if we use `Gauge.ratio` instead of `Gauge.percent`, and created an alternative PR using that approach: https://github.com/TrevorSatori/kronos/pull/32.

I prefer that one over this one, but I'm leaving both open — which one do you think is best?