### PR TITLE
fix: tagged_file.primary_tag() panics when music file contains no tag

### DIFF
--- a/src/helpers/gen_funcs.rs
+++ b/src/helpers/gen_funcs.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use glob::glob;
-use lofty::{Accessor, Probe, TaggedFileExt};
+use lofty::{Accessor, AudioFile, Probe, TaggedFileExt};
 
 // converts queue items to what's displayed for user
 pub fn audio_display(path: &PathBuf) -> String {
@@ -16,16 +16,21 @@ pub fn audio_display(path: &PathBuf) -> String {
         .read()
         .expect("ERROR: Failed to read file!");
 
-    let ptag = tagged_file.primary_tag().unwrap();
-    let artist = ptag.artist();
+    // If the file contains a tag
+    if tagged_file.contains_tag() {
+        let ptag = tagged_file.primary_tag().unwrap();
+        let artist = ptag.artist();
 
-    // if filename
-    if let Some(i) = tagged_file.primary_tag().unwrap().title() {
-        // if artist data
-        if let Some(j) = artist {
-            format!("{artist} - {title}", artist = j, title = i)
+        // if filename
+        if let Some(i) = tagged_file.primary_tag().unwrap().title() {
+            // if artist data
+            if let Some(j) = artist {
+                format!("{artist} - {title}", artist = j, title = i)
+            } else {
+                i.into()
+            }
         } else {
-            i.into()
+            path.file_name().unwrap().to_str().unwrap().to_string()
         }
     } else {
         path.file_name().unwrap().to_str().unwrap().to_string()


### PR DESCRIPTION
I was playing a list of music when I received the following error on a particular song every time:

thread 'main' panicked at src/helpers/gen_funcs.rs:19:42:called `Option::unwrap()` on a `None` value

I found the issue. One file I had contained no tags. The tagged_file in gen_funcs.rs doesn't do a check to see if the file contains_tag(). Added in the check and tested and now it no longer panics.